### PR TITLE
更新matlib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
       <dependency>
           <groupId>com.github.m1919810</groupId>
           <artifactId>matlib</artifactId>
-          <version>327725e7fa</version>
+          <version>344aa5f4c1</version>
           <scope>compile</scope>
       </dependency>
   </dependencies>


### PR DESCRIPTION
要不1.21.8无法往ME里放入粘液物品